### PR TITLE
Remove jQuery from gem to prevent potential jQuery version collisions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  MediaelementRails #
 
-This neat project brings the cool [MediaElement.js](http://mediaelementjs.com/) (HTML5/Flash/Silverlight video player) to the Rails asset pipeline.
+This neat project brings the cool [MediaElement.js](http://mediaelementjs.com/) (HTML5/Flash/Silverlight video player) to the Rails asset pipeline. __*NOTE:*__ This gem requires jquery, which shouldn't be an issue.
 
 ## All you have to do is: ##
 

--- a/app/assets/javascripts/mediaelement_rails/index.js
+++ b/app/assets/javascripts/mediaelement_rails/index.js
@@ -1,3 +1,2 @@
-//= require jquery
 //= require ./rails
 //= require ./mediaelementplayer


### PR DESCRIPTION
Because jQuery is commonly used in most Rails 3+ applications, it should not be loaded in any gem. This will prevent duplicate loads of possibly different versions of jQuery in a given application.
