### PR TITLE
Removed references to jQuery from tests.

### DIFF
--- a/test/integration/assets_test.rb
+++ b/test/integration/assets_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
 class AssetsTest < ActionDispatch::IntegrationTest
+
   test "includes full library" do
     get "/assets/mediaelement-and-player.js"
     assert_response :success
     assert content_type("text/javascript")
-    assert response_includes?("var jQuery = function( selector, context ) {")
     assert response_includes?("var mejs = mejs || {}")
     assert response_includes?("mejs.MediaElementPlayer.prototype = {")
   end
@@ -14,7 +14,6 @@ class AssetsTest < ActionDispatch::IntegrationTest
     get "/assets/mediaelement-without-player.js"
     assert_response :success
     assert content_type("text/javascript")
-    assert !response_includes?("var jQuery = function( selector, context ) {")
     assert response_includes?("var mejs = mejs || {}")
     assert !response_includes?("mejs.MediaElementPlayer.prototype = {")
   end


### PR DESCRIPTION
Assets test still referenced jQuery which was removed in commit
06d4bc8b84088. This caused tests to fail with:

```
 FAIL (0:00:00.058) includes full library
      Failed assertion, no message given.
    @ /home/mike/.rbenv/versions/1.9.3-rc1/lib/ruby/1.9.1/minitest/unit.rb:185:in `assert'
      test/integration/assets_test.rb:9:in `block in <class:AssetsTest>'
```

The test suite is now passing.
